### PR TITLE
Fix Contact block width

### DIFF
--- a/templates/_includes/components/content/form.twig
+++ b/templates/_includes/components/content/form.twig
@@ -3,17 +3,27 @@
 {% set isFirst = isFirst is not defined ? false : isFirst %}
 {% set isLast = isLast is not defined ? false : isLast %}
 {% set form = form is defined and form ? form : (block ? block.form : null) %}
-{% set attrs = {
-  id: 'contact-' ~ form.id
-} %}
+{% set container = container is defined ? container : true %}
+{% set attrs = { id: 'contact-' ~ form.id } %}
 {% set attrs = attributes is defined ? attrs|merge(attributes) : attrs %}
 
 {% if form %}
-  {{ sprig('_includes/components/forms/contact',
-    {
-      formId: form.id,
-      heading: block and block.heading is defined ? block.heading : false,
-    },
-    attrs
-  ) }}
+    {% set formOutput %}
+        {{ sprig('_includes/components/forms/contact',
+            {
+                formId: form.id,
+                heading: block and block.heading is defined ? block.heading : false,
+            },
+            attrs
+        ) }}
+    {% endset %}
+
+    {% if container %}
+        <div class="container pb-8">
+            {{ formOutput }}
+        </div>
+    {% else %}
+        {{ formOutput }}
+    {% endif %}
+
 {% endif %}

--- a/templates/_includes/components/forms/contact.twig
+++ b/templates/_includes/components/forms/contact.twig
@@ -11,7 +11,7 @@
   <!-- Template: {{ _self }}.twig -->
   <div class="relative">
     {{ form.renderTag() }}
-    <div class="flex justify-center container pb-8">
+    <div class="flex justify-center">
       <div class="w-full max-w-3xl">
         {% if heading %}
           <h2 class="text-xl">{{ heading }}</h2>

--- a/templates/_views/contact/index.twig
+++ b/templates/_views/contact/index.twig
@@ -18,7 +18,8 @@
       {% if form %}
         {% include '_includes/components/content/form' with {
           form: form,
-          attributes: { class: 'w-full' }
+          attributes: { class: 'w-full' },
+          container: false,
         } %}
       {% endif %}
     </div>

--- a/templates/_views/products/bike.twig
+++ b/templates/_views/products/bike.twig
@@ -226,7 +226,8 @@
               block: {
                 form: form,
                 heading: 'Have a question? Ask us!'|t
-              }
+              },
+              container: false,
             } only %}
           </div>
         {% endif %}


### PR DESCRIPTION
### Description

On an article using a **Form** block like “Adventure Journal on the Pine Moutain 2” [sic], the form reclines uncomfortably across the viewport:

<img width="1197" alt="before" src="https://user-images.githubusercontent.com/2488775/125532509-1aee3eba-9bec-4ff6-801e-8c45bdbe0b64.png">

This adds a `container` class like the preceding **Body** block, limits the max width of its child element, and adds some bottom padding.

<img width="1197" alt="after" src="https://user-images.githubusercontent.com/2488775/125532609-94b1c658-788b-4988-ba0d-19bc0f254d2a.png">

Made sure things are sensible when the viewport narrows as well:

<img width="400" alt="after-narrower" src="https://user-images.githubusercontent.com/2488775/125532626-9d31445b-0bcf-4052-a7de-acc88df13617.png">

Not sure whether this has any implications elsewhere, hence the PR.
