### PR TITLE
Fixes front-end build with pinned version of sanitize.css

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
   },
   "dependencies": {
     "alpinejs": "^2.8.2",
+    "sanitize.css": "^12.0.1",
     "swiper": "^6.8.4",
     "tailwindcss": "^2.2.19"
   }


### PR DESCRIPTION
### Description

Currently, with a fresh version of Spoke & Chain, the front-end build will fail.

```sh
nitro create craftcms/spoke-and-chain spokeandchain
nvm use
npm install
npm run build
```

…will give you something like “Loading PostCSS "postcss-normalize" plugin failed: Cannot find module 'sanitize.css/page.css'”

Apparently, postcss-normalize v9.x has a dependency on sanitize.css, with a version set to `*`, rather than any specific version. So, sanitize.css released a major version (removing page.css), which breaks the build of projects using postcss-normalize. This is still the case with postcss-normalize v10.x.

Possible fixes:

1. Add a specific version of `sanitize.css` directly to this project
2. Add `sanitize.css` (or another normalizing CSS file) directly to this project, and import all of it instead of using postcss-normalize at all

I’ve gone with the first option in this PR, but it seems like the second option might be easier to manage longer term (and probably wouldn’t add much extra CSS), based on this.