### PR TITLE
Update (removed) payment sources method

### DIFF
--- a/templates/_includes/components/payment/sourcesList.twig
+++ b/templates/_includes/components/payment/sourcesList.twig
@@ -1,7 +1,7 @@
 
 {% set radio = radio is not defined ? false : radio %}
 {% set account = account is not defined ? true : account %}
-{% set paymentSources = craft.commerce.paymentSources.getAllPaymentSourcesByUserId(currentUser.id) %}
+{% set paymentSources = craft.commerce.paymentSources.getAllPaymentSourcesByCustomerId(currentUser.id) %}
 
 <!-- Template: {{ _self }}.twig -->
 <div class="space-y-2">


### PR DESCRIPTION
Replaced getAllPaymentSourcesByUserId with getAllPaymentSourcesByCustomerId to reflect the changes from Commerce where that function has been removed in 5.x

### Description
The removed method `getAllPaymentSourcesByUserId` was not updated when migrating the project to Craft Commerce 5 and has now been replaced in the file submitted by this commit.


### Related issues
The URL `/account/settings` could not be accessed.
